### PR TITLE
address_history_info(): limit history to last 10 transactions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Basic functions
         Returns False on failure (for example NotEnoughFunds) or the hash of the transaction if success.
 
     -- address_history_info(address)
-        Returns dict with info of all transactions of the address history.
+        Return list with info of last 10 transactions of the address history.
         address is a wallet's address.
 
     -- def new_fair_address(entity_id, entity = 'generic')

--- a/electrum_fair_nrp.py
+++ b/electrum_fair_nrp.py
@@ -108,14 +108,14 @@ def make_transaction_from_address(address_origin, address_end, amount):
          logging.error("Sending %s fairs to the address %s" %(amount_total, address_end ) )
          return False
          
-def address_history_info(address):
-    """Return list with info of last 10 transactions of the address history"""
+def address_history_info(address, page = 0, items = 20):
+    """Return list with info of last 20 transactions of the address history"""
     return_history = []
-    tx_num = 0
     history = cmd_wallet.getaddresshistory(address)
-    for one_transaction in history:
+    tx_num = 0
+    for i, one_transaction in enumerate(history, start = page * items):
         tx_num += 1
-        if tx_num > 10:
+        if tx_num > items:
             return return_history
         raw_transaction = cmd_wallet.gettransaction(one_transaction['tx_hash'])
         info_transaction = raw_transaction.deserialize()

--- a/electrum_fair_nrp.py
+++ b/electrum_fair_nrp.py
@@ -109,10 +109,14 @@ def make_transaction_from_address(address_origin, address_end, amount):
          return False
          
 def address_history_info(address):
-    """ Return dict with info of all transactions of the address history"""
+    """Return list with info of last 10 transactions of the address history"""
     return_history = []
+    tx_num = 0
     history = cmd_wallet.getaddresshistory(address)
     for one_transaction in history:
+        tx_num += 1
+        if tx_num > 10:
+            return return_history
         raw_transaction = cmd_wallet.gettransaction(one_transaction['tx_hash'])
         info_transaction = raw_transaction.deserialize()
         return_history.append({'tx_hash': one_transaction['tx_hash'], 'tx_data': info_transaction})


### PR DESCRIPTION
Limit address history to last 10 transactions in address_history_info(). Protection for very large address histories. Maybe it could be improved with a pager?